### PR TITLE
Fix/long ens names

### DIFF
--- a/packages/nextjs/components/Contributions.tsx
+++ b/packages/nextjs/components/Contributions.tsx
@@ -48,7 +48,7 @@ export const Contributions = ({ withdrawEvents, isLoadingWithdrawEvents }: Contr
               data-test={`${event.log.address}_${event.log.blockNumber}`}
             >
               <div className="flex flex-row justify-between px-2">
-                <div className="w-1/3">
+                <div className="w-3/6">
                   <div>
                     <Address address={event.args.to} />
                   </div>
@@ -57,7 +57,7 @@ export const Contributions = ({ withdrawEvents, isLoadingWithdrawEvents }: Contr
                     <strong>Ξ {ethers.utils.formatEther(event.args.amount)}</strong>
                   </div>
                 </div>
-                <div className="w-2/3 text-left">{event.args.reason}</div>
+                <div className="w-3/6 text-left text-sm">{event.args.reason}</div>
               </div>
             </div>
           );

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -78,7 +78,7 @@ export const Address = ({ address, disableAddressLink, format }: TAddressProps) 
         <span className="ml-1.5 text-lg font-normal">{displayAddress}</span>
       ) : (
         <a
-          className="ml-1.5 text-lg font-normal"
+          className={`ml-1.5 font-normal ${ens && ens?.length > 15 ? "text-md" : "text-lg"}`}
           target="_blank"
           href={blockExplorerAddressLink}
           rel="noopener noreferrer"

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -78,7 +78,7 @@ export const Address = ({ address, disableAddressLink, format }: TAddressProps) 
         <span className="ml-1.5 text-lg font-normal">{displayAddress}</span>
       ) : (
         <a
-          className={`ml-1.5 font-normal ${ens && ens?.length > 15 ? "text-md" : "text-lg"}`}
+          className={`ml-1.5 font-normal ${ens && ens?.length > 15 ? "text-base" : "text-lg"}`}
           target="_blank"
           href={blockExplorerAddressLink}
           rel="noopener noreferrer"


### PR DESCRIPTION
Description
This PR fixes the long ens names overflowing.

See the changes on: [https://address-vision-port-git-feat-remove-see-on-buidlguidldao.vercel.app/](https://github.com/BuidlGuidl/address-vision-port/pull/url)

Additional Information
 I have read the [contributing docs](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
 This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
Related Issues
_Closes # _

Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request.

Your ENS/address: portdev.eth