### PR TITLE
Server Error when USD amount changed was fixed

### DIFF
--- a/packages/nextjs/components/StreamContract.tsx
+++ b/packages/nextjs/components/StreamContract.tsx
@@ -31,7 +31,7 @@ export const StreamContract = ({ amIAStreamedBuilder }: StreamContractProps) => 
   const { writeAsync: doWithdraw } = useScaffoldContractWrite({
     contractName: "YourContract",
     functionName: "streamWithdraw",
-    args: [ethers.utils.parseEther(amount || "0"), reason],
+    args: [ethers.utils.parseEther(Number(amount).toFixed(18) || "0"), reason],
   });
 
   return (


### PR DESCRIPTION
When the user change the USD amount while withdraw, it was given underflow error about decimals. 